### PR TITLE
Fix lambda_function.py file compression

### DIFF
--- a/src/code/setup.sh
+++ b/src/code/setup.sh
@@ -40,7 +40,7 @@ sed -i "s/find_library('zbar')/('\/opt\/python\/lib\/python3.7\/site-packages\/p
 zip -r pyzbar_layer.zip python && rm -rf python && rm -rf zbar
 
 #package lambda function code in a .zip
-zip -r lambda_function.zip Barcode-QR-Decoder-Lambda/src/code/lambda_function.zip
+zip -r lambda_function.zip Barcode-QR-Decoder-Lambda/src/code/lambda_function.py
 aws s3 sync . s3://$BUCKET_NAME/BarcodeQRDecoder/qr-reader/assets --exclude="*" --include="*layer.zip" --include="lambda_function.zip"
 
 #delete generated lambda layers after uploaded to S3 to clean curent directory


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The command line to compress the lambda_function.py file seems to be pointing to a file that doesn't exist yet(lambda_function.zip), I changed it to lambda_function.py. 

You can close this PR if this is not the case.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
